### PR TITLE
Make link clickable in call stacks

### DIFF
--- a/development.setup.english.md
+++ b/development.setup.english.md
@@ -605,6 +605,7 @@ xdebug.remote_autostart=1
 xdebug.remote_host=localhost
 xdebug.remote_handler=dbgp
 xdebug.remote_port=9000
+xdebug.file_link_format="phpstorm://open?file=%f&line=%l"
 ```
 
 PHP 5.6:
@@ -623,6 +624,7 @@ xdebug.remote_autostart=1
 xdebug.remote_host=localhost
 xdebug.remote_handler=dbgp
 xdebug.remote_port=9000
+xdebug.file_link_format="phpstorm://open?file=%f&line=%l"
 ```
 
 PHP 7.0:
@@ -641,6 +643,7 @@ xdebug.remote_autostart=1
 xdebug.remote_host=localhost
 xdebug.remote_handler=dbgp
 xdebug.remote_port=9000
+xdebug.file_link_format="phpstorm://open?file=%f&line=%l"
 ```
 
 PHP 7.1:
@@ -659,6 +662,7 @@ xdebug.remote_autostart=1
 xdebug.remote_host=localhost
 xdebug.remote_handler=dbgp
 xdebug.remote_port=9000
+xdebug.file_link_format="phpstorm://open?file=%f&line=%l"
 ```
 
 Restart Apache:


### PR DESCRIPTION
This setting turns filenames in call stacks into clickable links that open in PhpStorm