### PR TITLE
Added info on new Dovecot version

### DIFF
--- a/development.setup.english.md
+++ b/development.setup.english.md
@@ -970,6 +970,17 @@ With:
 #ssl_key = </etc/ssl/private/dovecot.pem
 ```
 
+In case you are using or upgrading to Dovecot 2.3.1 it is necessary to add the following line as well:
+
+```
+default_internal_group = mail
+```
+
+To find out which Dovecot version you are running, run this command:
+
+```
+dovecot --version
+```
 
 Set the permission on the mail folder. This is needed because otherwise Dovecot can't delete the messages and the log
 shows the error imap(YOURUSERNAME): Error: setegid(privileged) failed: Operation not permitted. This means the 


### PR DESCRIPTION
With the new Dovecot version things start to fall apart with the error message:
```
Fatal: service(stats) Group doesn't exist: dovecot (See service stats { unix_listener /usr/local/var/run/dovecot/stats-writer { group } } setting)
```

Adding the line mentioned in the PR fixes it and let's Dovecot start again.
Solution taken from: https://xdeb.org/post/2014/03/07/running-dovecot-as-a-local-only-imap-server-on-os-x/