### PR TITLE
Added instructions for installing MySQL 5.7

### DIFF
--- a/development.setup.dutch.md
+++ b/development.setup.dutch.md
@@ -406,18 +406,23 @@ Repeat these steps for PHP 7.0, 7.1 and 7.2.
 
 # MySQL installeren
 
+Let op, je kan niet verschillende versies van MySQL op dezelfde machine draaien omdat brew de database folder in
+dezelfde locatie plaatst. Kies daarom verstandig welke versie je wil installeren.
+
+### Installeren MySQL 8.0
+
 ```
 $ brew update
 $ brew install mysql
 ```
 
-### Start MySQL
+### Starten MySQL 8.0
 
 ```
 $ brew services start mysql
 ```
 
-### MySQL beveiligen
+### MySQL beveiligen 8.0
 
 ```
 $ /usr/local/bin/mysql_secure_installation
@@ -433,6 +438,27 @@ Remove anonymous users? y
 Disallow root login remotely? y
 Remove test database and access to it? y
 Reload privilege tables now? y
+```
+
+### Installeren MySQL 5.7
+
+Alle bestanden van MySQL 5.7 bevinden zich in de folder `/usr/local/opt/mysql@5.7/bin`
+
+```
+$ brew update
+$ brew install mysql@5.7
+```
+
+### Starten MySQL 5.7
+
+```
+$ brew services start mysql@5.7
+```
+
+### MySQL beveiligen 5.7
+
+```
+$ /usr/local/opt/mysql@5.7/bin/mysql_secure_installation
 ```
 
 # phpMyAdmin installeren

--- a/development.setup.english.md
+++ b/development.setup.english.md
@@ -416,6 +416,11 @@ Repeat these steps for PHP 7.0, 7.1 and 7.2.
 
 # MySQL installation
 
+Do note, you cannot run multiple versions of MySQL on the same machine because brew will install the database directory 
+in the same location. So choose wisely which version you want to install.
+
+### Install MySQL 8.0
+
 ```
 $ brew update
 $ brew install mysql
@@ -443,6 +448,27 @@ Remove anonymous users? (Press y|Y for Yes, any other key for No) : Y
 Disallow root login remotely? (Press y|Y for Yes, any other key for No) : Y
 Remove test database and access to it? (Press y|Y for Yes, any other key for No) : Y
 Reload privilege tables now? (Press y|Y for Yes, any other key for No) : Y
+```
+
+### Install MySQL 5.7
+
+All files for MySQL 5.7 will be located in the folder `/usr/local/opt/mysql@5.7/bin`
+
+```
+$ brew update
+$ brew install mysql@5.7
+```
+
+### Start MySQL
+
+```
+$ brew services start mysql@5.7
+```
+
+### Secure MySQL
+
+```
+$ /usr/local/opt/mysql@5.7/bin/mysql_secure_installation
 ```
 
 # phpMyAdmin installation
@@ -830,6 +856,9 @@ ps -aef | grep httpd
 ps -aef | grep mysql
 ```
 
+To use MySQL 5.7 use the following command to start MySQL
+`brew services start mysql@5.7`
+
 Save the file.
 
 ```
@@ -853,6 +882,9 @@ ps -aef | grep httpd
 ps -aef | grep mysql
 ```
 
+To use MySQL 5.7 use the following command to stop MySQL
+`brew services stop mysql@5.7`
+
 Save the file.
 
 ```
@@ -875,6 +907,9 @@ sudo apachectl -k restart
 ps -aef | grep httpd
 ps -aef | grep mysql
 ```
+
+To use MySQL 5.7 use the following command to stop MySQL
+`brew services restart mysql@5.7`
 
 Save the file.
 
@@ -1048,7 +1083,7 @@ default_internal_group = mail
 To find out which Dovecot version you are running, run this command:
 
 ```
-dovecot --version
+brew info dovecot
 ```
 
 Set the permission on the mail folder. This is needed because otherwise Dovecot can't delete the messages and the log


### PR DESCRIPTION
There is a major change when installing MySQL with brew as it will install 8.0 by default now and Joomla doesn't even connect to MySQL 8. This explains how to install MySQL 5.7 as an alternative.